### PR TITLE
jse_showkeys: add missing SetHudTextParams call

### DIFF
--- a/scripting/jse_showkeys.sp
+++ b/scripting/jse_showkeys.sp
@@ -208,6 +208,7 @@ public Action OnPlayerRunCmd(int iClient, int &iButtons, int &iImpulse, float fV
 				SetHudTextParams(g_fHUDCoords[iClient][0] - 0.05, g_fHUDCoords[iClient][1], TEXT_HOLD_TIME, g_iHUDColorsAlphaMultiplied[iClient][0], g_iHUDColorsAlphaMultiplied[iClient][1], g_iHUDColorsAlphaMultiplied[iClient][2], 255, 0, 0.0, 0.0, 0.0);
 				ShowSyncHudText(iClient, g_hHudText, sKeys);
 			} else {
+				SetHudTextParams(0, 0, 0.0, 0, 0, 0, 0, 0, 0, 0, 0);
 				ShowSyncHudText(iClient, g_hHudText, NULL_STRING);
 			}
 		}

--- a/scripting/jse_showkeys.sp
+++ b/scripting/jse_showkeys.sp
@@ -208,7 +208,7 @@ public Action OnPlayerRunCmd(int iClient, int &iButtons, int &iImpulse, float fV
 				SetHudTextParams(g_fHUDCoords[iClient][0] - 0.05, g_fHUDCoords[iClient][1], TEXT_HOLD_TIME, g_iHUDColorsAlphaMultiplied[iClient][0], g_iHUDColorsAlphaMultiplied[iClient][1], g_iHUDColorsAlphaMultiplied[iClient][2], 255, 0, 0.0, 0.0, 0.0);
 				ShowSyncHudText(iClient, g_hHudText, sKeys);
 			} else {
-				SetHudTextParams(0, 0, 0.0, 0, 0, 0, 0, 0, 0, 0, 0);
+				SetHudTextParams(0.0, 0.0, 0.0, 0, 0, 0, 0, 0, 0.0, 0.0, 0.0);
 				ShowSyncHudText(iClient, g_hHudText, NULL_STRING);
 			}
 		}


### PR DESCRIPTION
fixes the error below

```
L [SM] Exception reported: ShowSyncHudText first requires a call to SetHudTextParams or SetHudTextParamsEx
L [SM] Blaming: jse_showkeys.smx
L [SM] Call stack trace:
L [SM]   [0] ShowSyncHudText
L [SM]   [1] Line 211, jse_showkeys.sp::OnPlayerRunCmd
```